### PR TITLE
Fix for non always existing property to index

### DIFF
--- a/src/main/java/org/neo4j/batchimport/importer/AbstractLineData.java
+++ b/src/main/java/org/neo4j/batchimport/importer/AbstractLineData.java
@@ -89,11 +89,13 @@ public abstract class AbstractLineData implements LineData {
         for (int column = offset; column < headers.length; column++) {
             Header header = headers[column];
             if (header.indexName == null) continue;
+            Object val = getValue(column);
+            if (val == null) continue;
 
             if (!indexData.containsKey(header.indexName)) {
                 indexData.put(header.indexName, new HashMap<String, Object>());
             }
-            indexData.get(header.indexName).put(header.name,getValue(column));
+            indexData.get(header.indexName).put(header.name,val);
         }
         return indexData;
     }


### PR DESCRIPTION
My usecase:

**type**:string:node_auto_index publicId:string:node_auto_index name    reseller        registered:boolean      online:boolean
U       964c8274-69d5-4e1e-af20-be8bc2825a06@gmail.com  user 1  rf      true    false
U       1dd869f8-3c0e-4d3b-badf-146d96d80626@gmail.com  user 2  rf      true    false
U       1f285cde-9ec6-41cc-8990-2f0092ea79f9@gmail.com  user 3  rf      true    false
U               user 4  rf      false   false

i.e.: not always I have also a publicId to index on
