### PR TITLE
Introduce a new property in batch.properties to define a common directory for node and relationship CSVs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,15 +52,21 @@
             <version>2.0.3</version>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/org/neo4j/batchimport/utils/Config.java
+++ b/src/main/java/org/neo4j/batchimport/utils/Config.java
@@ -6,21 +6,13 @@ import org.neo4j.helpers.collection.MapUtil;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
+
+import static org.neo4j.batchimport.utils.Properties.*;
 
 public class Config {
-    public static final String BATCH_IMPORT_RELS_FILES = "batch_import.rels_files";
-    public static final String BATCH_IMPORT_GRAPH_DB = "batch_import.graph_db";
-    public static final String BATCH_IMPORT_KEEP_DB = "batch_import.keep_db";
     public static final String CONFIG_FILE_NAME = "batch.properties";
-    public static final String BATCH_IMPORT_NODES_FILES = "batch_import.nodes_files";
-    public static final String BATCH_IMPORT_MAPDB_CACHE_DISABLE = "batch_import.mapdb_cache.disable";
-    public static final String BATCH_IMPORT_CSV_QUOTES = "batch_import.csv.quotes";
-    public static final String BATCH_IMPORT_CSV_DELIM = "batch_import.csv.delim";
+
     private final Map<String, String> configData;
 
     public Config(Map<String, String> configData) {
@@ -60,13 +52,13 @@ public class Config {
 
     // todo more checks ?
     private static void validateConfig(Map<String, String> config) {
-        if (!config.containsKey(BATCH_IMPORT_GRAPH_DB)) throw new IllegalArgumentException("Missing parameter for graphdb directory");
+        if (!config.containsKey(BATCH_IMPORT_GRAPH_DB.key())) throw new IllegalArgumentException("Missing parameter for graphdb directory");
     }
 
     private static Collection<IndexInfo> convertParamsToConfig(Stack<String> args, Map<String, String> config) {
-        addConfigParamIfArgument(args, config, BATCH_IMPORT_GRAPH_DB);
-        addConfigParamIfArgument(args, config, BATCH_IMPORT_NODES_FILES);
-        addConfigParamIfArgument(args, config, BATCH_IMPORT_RELS_FILES);
+        addConfigParamIfArgument(args, config, BATCH_IMPORT_GRAPH_DB.key());
+        addConfigParamIfArgument(args, config, BATCH_IMPORT_NODES_FILES.key());
+        addConfigParamIfArgument(args, config, BATCH_IMPORT_RELS_FILES.key());
         Collection<IndexInfo> indexes = createIndexInfos(args);
         for (IndexInfo index : indexes) {
             index.addToConfig(config);
@@ -151,7 +143,7 @@ public class Config {
     }
 
     public boolean isCachedIndexDisabled() {
-        return configOptionEnabled(this, BATCH_IMPORT_MAPDB_CACHE_DISABLE);
+        return configOptionEnabled(this, BATCH_IMPORT_MAPDB_CACHE_DISABLE.key());
     }
 
     public Collection<IndexInfo> getIndexInfos() {
@@ -159,25 +151,25 @@ public class Config {
     }
 
     public Collection<File> getRelsFiles() {
-        return toFiles(get(BATCH_IMPORT_RELS_FILES));
+        return toFiles(get(BATCH_IMPORT_RELS_FILES.key()));
     }
 
     public Collection<File> getNodesFiles() {
-        return toFiles(get(BATCH_IMPORT_NODES_FILES));
+        return toFiles(get(BATCH_IMPORT_NODES_FILES.key()));
     }
 
     public char getDelimChar(Importer importer) {
-        final String delim = get(BATCH_IMPORT_CSV_DELIM);
+        final String delim = get(BATCH_IMPORT_CSV_DELIM.key());
         if (delim==null || delim.isEmpty()) return '\t';
         return delim.trim().charAt(0);
     }
 
     public boolean quotesEnabled() {
-        return configOptionEnabled(this, BATCH_IMPORT_CSV_QUOTES);
+        return configOptionEnabled(this, BATCH_IMPORT_CSV_QUOTES.key());
     }
 
     public String getGraphDbDirectory() {
-        return get(BATCH_IMPORT_GRAPH_DB);
+        return get(BATCH_IMPORT_GRAPH_DB.key());
     }
 
     String get(String option) {
@@ -185,7 +177,7 @@ public class Config {
     }
 
     public boolean keepDatabase() {
-        return configOptionEnabled(this, BATCH_IMPORT_KEEP_DB);
+        return configOptionEnabled(this, BATCH_IMPORT_KEEP_DB.key());
     }
 
     public Map<String, String> getConfigData() {

--- a/src/main/java/org/neo4j/batchimport/utils/Config.java
+++ b/src/main/java/org/neo4j/batchimport/utils/Config.java
@@ -10,6 +10,10 @@ import java.util.*;
 
 import static org.neo4j.batchimport.utils.Properties.*;
 
+/**
+ * @author mh
+ * @author Florent Biville (@fbiville)
+ */
 public class Config {
     public static final String CONFIG_FILE_NAME = "batch.properties";
 
@@ -125,10 +129,12 @@ public class Config {
         return "true".equalsIgnoreCase(config.get(option));
     }
 
-    public static Collection<File> toFiles(String commaSeparatedFileList) {
+    public static Collection<File> toFiles(String commaSeparatedFileList,
+                                           String pathPrefix) {
+        String prefix = normalize(pathPrefix);
         Collection<File> files=new ArrayList<File>();
         for (String part : commaSeparatedFileList.split(",")) {
-            final File file = new File(part);
+            final File file = new File(prefix + part);
             if (file.exists() && file.canRead() && file.isFile()) files.add(file);
             else System.err.println("File "+file+" does not exist, can not be read or is not a file.");
         }
@@ -138,10 +144,10 @@ public class Config {
     public static String NODE_INDEX(String indexName) {
         return "batch_import.node_index." + indexName;
     }
+
     public static String RELATIONSHIP_INDEX(String indexName) {
         return "batch_import.relationship_index." + indexName;
     }
-
     public boolean isCachedIndexDisabled() {
         return configOptionEnabled(this, BATCH_IMPORT_MAPDB_CACHE_DISABLE.key());
     }
@@ -151,11 +157,17 @@ public class Config {
     }
 
     public Collection<File> getRelsFiles() {
-        return toFiles(get(BATCH_IMPORT_RELS_FILES.key()));
+        return toFiles(
+            get(BATCH_IMPORT_RELS_FILES.key()),
+            get(BATCH_IMPORT_PATH_PREFIX.key())
+        );
     }
 
     public Collection<File> getNodesFiles() {
-        return toFiles(get(BATCH_IMPORT_NODES_FILES.key()));
+        return toFiles(
+            get(BATCH_IMPORT_NODES_FILES.key()),
+            get(BATCH_IMPORT_PATH_PREFIX.key())
+        );
     }
 
     public char getDelimChar(Importer importer) {
@@ -172,15 +184,27 @@ public class Config {
         return get(BATCH_IMPORT_GRAPH_DB.key());
     }
 
-    String get(String option) {
-        return configData.get(option);
-    }
-
     public boolean keepDatabase() {
         return configOptionEnabled(this, BATCH_IMPORT_KEEP_DB.key());
     }
 
     public Map<String, String> getConfigData() {
         return configData;
+    }
+
+    /*testing*/String get(String option) {
+        return configData.get(option);
+    }
+
+    /*testing*/static String normalize(String pathPrefix) {
+        if (pathPrefix == null) {
+            return "";
+        }
+
+        if (pathPrefix.charAt(pathPrefix.length() - 1) == File.separatorChar) {
+            return pathPrefix;
+        }
+
+        return pathPrefix + File.separatorChar;
     }
 }

--- a/src/main/java/org/neo4j/batchimport/utils/Properties.java
+++ b/src/main/java/org/neo4j/batchimport/utils/Properties.java
@@ -1,0 +1,26 @@
+package org.neo4j.batchimport.utils;
+
+/**
+ * Configuration keys
+ * @author Florent Biville (@fbiville)
+ */
+public enum Properties {
+
+    BATCH_IMPORT_RELS_FILES("batch_import.rels_files"),
+    BATCH_IMPORT_GRAPH_DB("batch_import.graph_db"),
+    BATCH_IMPORT_KEEP_DB("batch_import.keep_db"),
+    BATCH_IMPORT_NODES_FILES("batch_import.nodes_files"),
+    BATCH_IMPORT_MAPDB_CACHE_DISABLE("batch_import.mapdb_cache.disable"),
+    BATCH_IMPORT_CSV_QUOTES("batch_import.csv.quotes"),
+    BATCH_IMPORT_CSV_DELIM("batch_import.csv.delim");
+
+    private final String key;
+
+    Properties(String key) {
+        this.key = key;
+    }
+
+    public String key() {
+        return key;
+    }
+}

--- a/src/main/java/org/neo4j/batchimport/utils/Properties.java
+++ b/src/main/java/org/neo4j/batchimport/utils/Properties.java
@@ -5,7 +5,7 @@ package org.neo4j.batchimport.utils;
  * @author Florent Biville (@fbiville)
  */
 public enum Properties {
-
+    BATCH_IMPORT_PATH_PREFIX("batch_import.file_path"),
     BATCH_IMPORT_RELS_FILES("batch_import.rels_files"),
     BATCH_IMPORT_GRAPH_DB("batch_import.graph_db"),
     BATCH_IMPORT_KEEP_DB("batch_import.keep_db"),

--- a/src/test/java/org/neo4j/batchimport/utils/ConfigTest.java
+++ b/src/test/java/org/neo4j/batchimport/utils/ConfigTest.java
@@ -40,7 +40,7 @@ public class ConfigTest {
     @Test
     public void testExtractDatabaseDir() throws Exception {
         assertCommandLine("data/dir",
-                          "data/dir", Config.BATCH_IMPORT_GRAPH_DB);
+                          "data/dir", Properties.BATCH_IMPORT_GRAPH_DB.key());
     }
 
     @Test
@@ -54,13 +54,13 @@ public class ConfigTest {
     @Test
     public void testExtractNodesFiles() throws Exception {
         assertCommandLine("data/dir "+nodesFile.getAbsolutePath(),
-                          nodesFile.getAbsolutePath(), Config.BATCH_IMPORT_NODES_FILES);
+                          nodesFile.getAbsolutePath(), Properties.BATCH_IMPORT_NODES_FILES.key());
     }
 
     @Test
     public void testExtractRelsFiles() throws Exception {
         assertCommandLine("data/dir "+nodesFile.getAbsolutePath()+" "+relsFile.getAbsolutePath(),
-                          relsFile.getAbsolutePath(), Config.BATCH_IMPORT_RELS_FILES);
+                          relsFile.getAbsolutePath(), Properties.BATCH_IMPORT_RELS_FILES.key());
     }
 
     @Test

--- a/src/test/java/org/neo4j/batchimport/utils/ConfigTest.java
+++ b/src/test/java/org/neo4j/batchimport/utils/ConfigTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class ConfigTest {
@@ -45,7 +46,7 @@ public class ConfigTest {
 
     @Test
     public void testToFiles() throws Exception {
-        final Collection<File> files = Config.toFiles("null,,foo," + nodesFile.getAbsolutePath());
+        final Collection<File> files = Config.toFiles("null,,foo," + nodesFile.getAbsolutePath(), null);
         assertEquals(1,files.size());
         assertEquals(nodesFile.getAbsolutePath(),files.iterator().next().getAbsolutePath());
 
@@ -99,6 +100,21 @@ public class ConfigTest {
     @Test(expected = IllegalArgumentException.class)
     public void testFailsOnNoArguments() throws Exception {
         assertCommandLine("",null,null);
+    }
+
+    @Test
+    public void should_return_empty_string_for_null_path_prefix() {
+        assertThat(Config.normalize(null)).isEqualTo("");
+    }
+
+    @Test
+    public void should_return_string_as_is_if_ending_slash_is_present() {
+        assertThat(Config.normalize("test/")).isEqualTo("test" + File.separatorChar);
+    }
+
+    @Test
+    public void should_return_string_appended_with_slash_as_is_if_no_ending_slash_is_present() {
+        assertThat(Config.normalize("foo")).isEqualTo("foo" + File.separatorChar);
     }
 
     private void assertCommandLine(String arguments, String expected, String optionName) {


### PR DESCRIPTION
In batch.properties, rather than repeating the same possible common directory, let me introduce a new option 'batch_import.file_path' that will automatically be prepended to each CSV path.

Note that this option is not mandatory, thus preserving backwards-compatibility.
