### PR TITLE
bugfix replace space with tab in sample/rel.csv

### DIFF
--- a/sample/rels.csv
+++ b/sample/rels.csv
@@ -1,6 +1,6 @@
 name:string:users	name:string:users	type	since	counter:int
-Michael	Selina	FATHER_OF 1998-07-10	1
-Michael	Rana	FATHER_OF 2007-09-15	2
-Michael	Selma	FATHER_OF 2008-05-03	3
-Rana	Selma	SISTER_OF 2008-05-03	5
-Selina	Rana	SISTER_OF 2007-09-15	7
+Michael	Selina	FATHER_OF	1998-07-10	1
+Michael	Rana	FATHER_OF	2007-09-15	2
+Michael	Selma	FATHER_OF	2008-05-03	3
+Rana	Selma	SISTER_OF	2008-05-03	5
+Selina	Rana	SISTER_OF	2007-09-15	7


### PR DESCRIPTION
The relations file in `sample/rels.csv` is not correct formatted. The columns `type` and `since` are separated by a space instead of a tab. 
This result in:

```
{"endNodeId":4,"relationshipType":"FATHER_OF 2008-05-03","id":2,"propertyMap":{"since":"3"}}
```

instead of:

```
{"endNodeId":4,"relationshipType":"FATHER_OF","id":2,"propertyMap":{"counter":3,"since":"2008-05-03"}}
```

Accepting all white spaces as separators or better using commas to separate the columns would make it a lot
easier to spot this kind of errors.

Best,
Immanuel
