### PR TITLE
Custom Separators for Arrays 

### DIFF
--- a/batch.properties
+++ b/batch.properties
@@ -7,3 +7,4 @@ neostore.nodestore.db.mapped_memory=200M
 neostore.relationshipstore.db.mapped_memory=500M
 neostore.propertystore.db.mapped_memory=200M
 neostore.propertystore.db.strings.mapped_memory=200M
+batch_array_separator=,

--- a/src/main/java/org/neo4j/batchimport/importer/Type.java
+++ b/src/main/java/org/neo4j/batchimport/importer/Type.java
@@ -1,5 +1,7 @@
 package org.neo4j.batchimport.importer;
 
+import org.neo4j.batchimport.utils.Config;
+
 public enum Type {
     ID {
         @Override
@@ -72,7 +74,7 @@ public enum Type {
     BOOLEAN_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             boolean[] booleanArray = new boolean[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 booleanArray[i] = Boolean.valueOf(strArray[i]);
@@ -83,7 +85,7 @@ public enum Type {
     INT_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             int[] intArray = new int[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 intArray[i] = Integer.parseInt(strArray[i]);
@@ -94,7 +96,7 @@ public enum Type {
     LONG_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             long[] longArray = new long[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 longArray[i] = Long.parseLong(strArray[i]);
@@ -105,7 +107,7 @@ public enum Type {
     DOUBLE_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             double[] doubleArray = new double[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 doubleArray[i] = Double.parseDouble(strArray[i]);
@@ -116,7 +118,7 @@ public enum Type {
     FLOAT_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             float[] floatArray = new float[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 floatArray[i] = Float.parseFloat(strArray[i]);
@@ -127,7 +129,7 @@ public enum Type {
     BYTE_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             byte[] byteArray = new byte[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 byteArray[i] = Byte.parseByte(strArray[i]);
@@ -138,7 +140,7 @@ public enum Type {
     SHORT_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             short[] shortArray = new short[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 shortArray[i] = Short.parseShort(strArray[i]);
@@ -149,7 +151,7 @@ public enum Type {
     CHAR_ARRAY {
         @Override
         public Object convert(String value) {
-            String[] strArray = value.split(",");
+            String[] strArray = value.split(Config.ARRAYS_SEPARATOR);
             char[] charArray = new char[strArray.length];
             for(int i = 0; i < strArray.length; i++) {
                 charArray[i] = strArray[i].charAt(0);
@@ -160,7 +162,8 @@ public enum Type {
     STRING_ARRAY {
         @Override
         public Object convert(String value) {
-            return value.split(",");
+            String separator = Config.ARRAYS_SEPARATOR;
+            return value.split(Config.ARRAYS_SEPARATOR);
         }
     };
 

--- a/src/main/java/org/neo4j/batchimport/utils/Config.java
+++ b/src/main/java/org/neo4j/batchimport/utils/Config.java
@@ -21,10 +21,16 @@ public class Config {
     public static final String BATCH_IMPORT_MAPDB_CACHE_DISABLE = "batch_import.mapdb_cache.disable";
     public static final String BATCH_IMPORT_CSV_QUOTES = "batch_import.csv.quotes";
     public static final String BATCH_IMPORT_CSV_DELIM = "batch_import.csv.delim";
+    public static final String ARRAY_SEPARATOR_CONFIG = "batch_array_separator";
+    public static String ARRAYS_SEPARATOR = ",";
+
     private final Map<String, String> configData;
 
     public Config(Map<String, String> configData) {
         this.configData = configData;
+        if (this.configData.containsKey(ARRAY_SEPARATOR_CONFIG)){
+            Config.ARRAYS_SEPARATOR = configData.get(ARRAY_SEPARATOR_CONFIG);
+         }
     }
 
     public static Config convertArgumentsToConfig(String[] args) {

--- a/src/test/java/org/neo4j/batchimport/ImporterTest.java
+++ b/src/test/java/org/neo4j/batchimport/ImporterTest.java
@@ -17,6 +17,8 @@ import java.util.Arrays;
 import java.util.Map;
 
 import static java.util.Arrays.*;
+import org.junit.Assert;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.neo4j.helpers.collection.MapUtil.map;
@@ -115,6 +117,29 @@ public class ImporterTest {
         importer.importNodes(new StringReader("a:int\tb:float\tc:float\n10\t10.0\t1E+10"));
         importer.finish();
         verify(inserter, times(1)).createNode(eq(map("a", 10,"b",10.0F,"c",1E+10F)));
+    }
+    
+    @Test
+    public void testImportNodeWithArrayTypes() throws Exception {
+        importer.importNodes(new StringReader("a:STRING_ARRAY\tb:float\tc:float\n10,11,12\t10.0\t1E+10"));
+        importer.finish();
+        String[] expectedArray = {"10","11","12"};
+        ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
+        verify(inserter, times(1)).createNode(argument.capture());
+        Map<String, Object> inputMap = argument.getValue();
+        Assert.assertArrayEquals((String[])inputMap.get("a"),expectedArray);   
+    }
+    
+    @Test
+    public void testImportNodeWithArrayTypesCustomSeparator() throws Exception {
+        Config.ARRAYS_SEPARATOR = "%";
+        importer.importNodes(new StringReader("a:STRING_ARRAY\tb:float\tc:float\n10%11%12\t10.0\t1E+10"));
+        importer.finish();
+        String[] expectedArray = {"10","11","12"};
+        ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
+        verify(inserter, times(1)).createNode(argument.capture());
+        Map<String, Object> inputMap = argument.getValue();
+        Assert.assertArrayEquals((String[])inputMap.get("a"),expectedArray);   
     }
 
     @Test

--- a/src/test/java/org/neo4j/batchimport/utils/ConfigTest.java
+++ b/src/test/java/org/neo4j/batchimport/utils/ConfigTest.java
@@ -4,7 +4,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
@@ -19,7 +21,7 @@ public class ConfigTest {
         final File tempFile;
         try {
             tempFile = File.createTempFile(prefix, "." + suffix, new File("target"));
-            tempFile.deleteOnExit();
+           tempFile.deleteOnExit();
             return tempFile;
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -28,6 +30,9 @@ public class ConfigTest {
 
     public ConfigTest() throws IOException {
         testConfigFile = createTempFile("test", "properties");
+        FileWriter fileWriter = new FileWriter(testConfigFile);
+        fileWriter.write(Config.ARRAY_SEPARATOR_CONFIG+"=|");
+        fileWriter.close();
     }
 
     @Before
@@ -36,7 +41,9 @@ public class ConfigTest {
     }
 
 //        final String[] args = "data/dir nodes.csv relationships.csv [node_index node-index-name fulltext|exact nodes_index.csv rel_index rel-index-name fulltext|exact rels_index.csv ....]".split(" ");
+    
 
+    
     @Test
     public void testExtractDatabaseDir() throws Exception {
         assertCommandLine("data/dir",
@@ -82,6 +89,13 @@ public class ConfigTest {
     public void testExtractFulltextNodeIndex() throws Exception {
         assertCommandLine("data/dir nodes.csv rels.csv node_index index-name fulltext",
                           "fulltext", Config.NODE_INDEX("index-name"));
+    }
+    
+    @Test
+    public void testCustomArraySeparator() throws Exception {
+            assertCommandLine("data/dir nodes.csv rels.csv node_index index-name fulltext",
+                          "|", Config.ARRAY_SEPARATOR_CONFIG);
+            Config.ARRAYS_SEPARATOR =",";
     }
 
     @Test


### PR DESCRIPTION
Following issue #62 this PR adds the option to define a custom separator for array variables.
- `,` is  the default separator
- The default separator can be changed by adding  `batch_array_separator` to `batch.properties`. i.e:
  
   `batch_array_separator=%`

best,

David
