### PR TITLE
Some improvements for import.sh

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -1,4 +1,11 @@
 HEAP=4G
+
+# Detect Cygwin
+case `uname -s` in
+CYGWIN*)
+    cygwin=1
+esac
+
 DB=${1-target/graph.db}
 shift
 NODES=${1-nodes.csv}
@@ -7,9 +14,19 @@ RELS=${1-rels.csv}
 shift
 CP=""
 base=`dirname "$0"`
+if [ \! -z "$cygwin" ]; then
+    wbase=`cygpath -w "$base"`
+fi
 curdir=`pwd`
 cd "$base"
-for i in lib/*.jar; do CP="$CP":"$base/$i"; done
+for i in lib/*.jar; do
+    if [ -z "$cygwin" ]; then
+        CP="$CP":"$base/$i"
+    else
+        i=`cygpath -w "$i"`
+        CP="$CP;$wbase/$i"
+    fi
+done
 cd "$curdir"
 #echo java -classpath $CP -Xmx$HEAP -Xms$HEAP -Dfile.encoding=UTF-8 org.neo4j.batchimport.Importer batch.properties "$DB" "$NODES" "$RELS" "$@"
 java -classpath "$CP" -Xmx$HEAP -Xms$HEAP -Dfile.encoding=UTF-8 org.neo4j.batchimport.Importer batch.properties "$DB" "$NODES" "$RELS" "$@"

--- a/import.sh
+++ b/import.sh
@@ -6,6 +6,10 @@ shift
 RELS=${1-rels.csv}
 shift
 CP=""
-for i in lib/*.jar; do CP="$CP":"$i"; done
+base=`dirname "$0"`
+curdir=`pwd`
+cd "$base"
+for i in lib/*.jar; do CP="$CP":"$base/$i"; done
+cd "$curdir"
 #echo java -classpath $CP -Xmx$HEAP -Xms$HEAP -Dfile.encoding=UTF-8 org.neo4j.batchimport.Importer batch.properties "$DB" "$NODES" "$RELS" "$@"
-java -classpath $CP -Xmx$HEAP -Xms$HEAP -Dfile.encoding=UTF-8 org.neo4j.batchimport.Importer batch.properties "$DB" "$NODES" "$RELS" "$@"
+java -classpath "$CP" -Xmx$HEAP -Xms$HEAP -Dfile.encoding=UTF-8 org.neo4j.batchimport.Importer batch.properties "$DB" "$NODES" "$RELS" "$@"


### PR DESCRIPTION
This pull request includes the following 2 improvements for import.sh.
- Remove the assumption that the current directory is the top directory. It enables us to call import.sh from other than the top directory, for example, by PATH search.
- Take care of Cygwin, that is Linux API layer for Win32, environment.

It is tested by Cygwin 1.7.25 and FreeBSD 9.1-STABLE.

If you want to split them, I will make 2 separated pull requests.
